### PR TITLE
Automated installation

### DIFF
--- a/bin/kubectl-job-watch
+++ b/bin/kubectl-job-watch
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-set -e
+set -eu
 
 job_name="$1"
 
-# Follow log for most recently scheduled job, or (newest) running job?
+# TODO: Follow log for most recently scheduled job, or (newest) running job?
 kubectl logs --follow "jobs/${job_name}"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+umask 077
+
+api_url="https://raw.githubusercontent.com/uitml/frink/master"
+
+mkdir -p /tmp/frink && cd /tmp/frink
+curl -LO "${api_url}/bin/kubectl-job-kill"
+curl -LO "${api_url}/bin/kubectl-job-list"
+curl -LO "${api_url}/bin/kubectl-job-run"
+curl -LO "${api_url}/bin/kubectl-job-watch"
+chmod +x kubectl*
+sudo cp --no-preserve=ownership kubectl* /usr/local/bin/

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -10,5 +10,5 @@ curl -LO "${api_url}/bin/kubectl-job-kill"
 curl -LO "${api_url}/bin/kubectl-job-list"
 curl -LO "${api_url}/bin/kubectl-job-run"
 curl -LO "${api_url}/bin/kubectl-job-watch"
-chmod +x kubectl*
 sudo cp --no-preserve=ownership kubectl* /usr/local/bin/
+sudo chmod 755 /usr/local/bin/kubectl-job-*


### PR DESCRIPTION
This PR adds a basic automated installation script for Frink. The script downloads all Frink scripts and installs them to `/usr/local/bin`. This location is searched by the plugin system used by `kubectl`, which should make the new Frink `job` command work automagically.

Note that Frink itself and this script is very much in an alpha state, and should be improved as soon as feasible.