### PR TITLE
Add version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,8 @@ builds:
   - linux
   goarch:
   - amd64
+  ldflags:
+  - -s -w -X github.com/uitml/frink/cmd.version={{ .Version }} -X github.com/uitml/frink/cmd.commit={{ .ShortCommit }}  -X github.com/uitml/frink/cmd.date={{ .Date }}
 
 archives:
 - format: binary

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version string
+	commit  string
+	date    string
+)
+
+var versionCmd = &cobra.Command{
+	Use: "version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("frink v%s\n", version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -4,12 +4,6 @@ import (
 	"github.com/uitml/frink/cmd"
 )
 
-var (
-	version string
-	commit  string
-	date    string
-)
-
 func main() {
 	cmd.Execute()
 }


### PR DESCRIPTION
This PR adds a `version` command to Frink. It doesn't have much use right now except helping users check the installed version. In the future, the version information will be part of a (semi-automated) update mechanism.